### PR TITLE
Fix generate_config failing when trying to create a dir with empty path

### DIFF
--- a/src/tesla_ce/client.py
+++ b/src/tesla_ce/client.py
@@ -321,8 +321,9 @@ class Client():
             config.set('MOODLE_ADMIN_PASSWORD', uuid.uuid4().__str__())
 
         # Check that output folder exists
-        if not os.path.exists(os.path.dirname(output_file)):
-            os.makedirs(os.path.dirname(output_file))
+        output_dir = os.path.dirname(output_file)
+        if output_dir != '' and not os.path.exists(output_dir):
+            os.makedirs(output_dir)
 
         # Write the configuration file to disk
         with open(output_file, 'w') as out_fh:


### PR DESCRIPTION
Using version 1.0.0 from pip.

While running `tesla_ce generate_config --local --with-services --with-moodle DOMAIN` with an existing config, I got an error:

```
TeSLA CE version 1.0.0
Output file: tesla-ce.cfg
Traceback (most recent call last):
--cut--
  File "--cut--/venv/lib64/python3.9/site-packages/tesla_ce/client.py", line 323, in generate_configuration
    os.makedirs(os.path.dirname(output_file))
  File "/usr/lib64/python3.9/os.py", line 225, in makedirs
    mkdir(name, mode)
FileNotFoundError: [Errno 2] No such file or directory: ''
```

In this case the variable `output_file` had a value of `tesla-ce.cfg`, which the os.path.dirname() converts to an empty string '', causing the error.